### PR TITLE
Implemented update for partitions, retention and cleanup policies

### DIFF
--- a/kafka_client_test.go
+++ b/kafka_client_test.go
@@ -46,6 +46,20 @@ Topic: file-imported	Partition: 11	Leader: -1	Replicas: 0	Isr:`
 	at kafka.admin.TopicCommand$.main(TopicCommand.scala:60)
 	at kafka.admin.TopicCommand.main(TopicCommand.scala)
  (kafka.admin.TopicCommand$)`
+
+  errorWithWarnings =
+`WARNING: If partitions are increased for a topic that has a key, the partition logic or ordering of the messages will be affected
+Error while executing topic command : The number of partitions for a topic can only be increased
+[2016-03-15 15:20:05,571] ERROR kafka.admin.AdminOperationException: The number of partitions for a topic can only be increased
+	at kafka.admin.AdminUtils$.addPartitions(AdminUtils.scala:119)
+	at kafka.admin.TopicCommand$$anonfun$alterTopic$1.apply(TopicCommand.scala:139)
+	at kafka.admin.TopicCommand$$anonfun$alterTopic$1.apply(TopicCommand.scala:116)
+	at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
+	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
+	at kafka.admin.TopicCommand$.alterTopic(TopicCommand.scala:116)
+	at kafka.admin.TopicCommand$.main(TopicCommand.scala:62)
+	at kafka.admin.TopicCommand.main(TopicCommand.scala)
+ (kafka.admin.TopicCommand$)`
 )
 
 func TestKafkaManagingClient_topicInfo(t *testing.T) {
@@ -102,6 +116,15 @@ func TestKafkaManagingClient_emptyTopicInfo(t *testing.T) {
 func TestKafkaManagingClient_invalidResponseTopicInfo(t *testing.T) {
   _, err := readTopicInfo(invalidDescribeResponse)
   if err == nil { t.Fatal("Error is expected, but success found. Sometimes success is not what you are after.") }
+}
+
+func TestKafkaManagingClient_errorWithWarnings(t *testing.T) {
+  err := readError(errorWithWarnings)
+
+  if err == nil { t.Fatal("Error is expected, but success found. Sometimes success is not what you are after.") }
+  if err.Error() != "Error while executing topic command : The number of partitions for a topic can only be increased" {
+    t.Errorf("Unexpected error message: '%s'", err.Error())
+  }
 }
 
 func TestKafkaManagingClient_parseNoBrokersError(t *testing.T) {

--- a/kafka_topic_info.go
+++ b/kafka_topic_info.go
@@ -1,0 +1,60 @@
+package main
+import "strconv"
+
+type KafkaTopicInfo struct {
+  PartitionsCount int
+  ReplicationFactor int
+  CleanupPolicy string
+  RetentionBytes int64
+  RetentionMs int64
+}
+
+func appendConf(slice []string, name string, value string) []string {
+  return append(slice, "--config", name + "=" + value)
+}
+
+func addConf(slice []string, name string, value string) []string {
+  return append(slice, "--add-config", name + "=" + value)
+}
+
+func removeConf(slice []string, name string) []string {
+  return append(slice, "--delete-config", name)
+}
+
+func setConf(slice []string, name string, value string, nullValue string) []string {
+  if nullValue == value {
+    return removeConf(slice, name)
+  } else {
+    return addConf(slice, name, value)
+  }
+}
+
+func setConfInt(slice []string, name string, value int, nullValue int) []string {
+  return setConf(slice, name, strconv.Itoa(value), strconv.Itoa(nullValue))
+}
+
+func setConfInt64(slice []string, name string, value int64, nullValue int64) []string {
+  return setConf(slice, name, strconv.FormatInt(value, 10), strconv.FormatInt(nullValue, 10))
+}
+
+func (conf *KafkaTopicInfo) alterTopicConfigOpts() []string {
+  var parms = []string{}
+  parms = setConf      (parms, "cleanup.policy",  conf.CleanupPolicy,  "")
+  parms = setConfInt64 (parms, "retention.bytes", conf.RetentionBytes, -1)
+  parms = setConfInt64 (parms, "retention.ms",    conf.RetentionMs,    -1)
+
+  return parms
+}
+
+func(conf *KafkaTopicInfo) createTopicConfigOpts() []string {
+  var parms = []string{}
+  if (conf.CleanupPolicy != "") { parms = appendConf(parms, "cleanup.policy", conf.CleanupPolicy ) }
+  if (conf.RetentionBytes > -1) { parms = appendConf(parms, "retention.bytes", strconv.FormatInt(conf.RetentionBytes, 10))}
+  if (conf.RetentionMs > -1)    { parms = appendConf(parms, "retention.ms", strconv.FormatInt(conf.RetentionMs, 10))}
+
+  return parms
+}
+
+func(info *KafkaTopicInfo) exists() bool {
+  return info != nil && info.PartitionsCount > 0 && info.ReplicationFactor > 0
+}

--- a/sample/sample.tf
+++ b/sample/sample.tf
@@ -4,9 +4,9 @@ provider "kafka" {
 }
 
 resource "kafka_topic" "my-test" {
-  name = "test12"
-  partitions = 3
+  name = "my-test"
+  partitions = 2
   replication_factor = 1
-  retention_ms = 86000
+  retention_ms = 300000
   cleanup_policy = "compact"
 }


### PR DESCRIPTION
- Can update partitions
- Cannot update replication factor so force new (It can be done in Kafka, but requires manual brokers assignment and probably outside of the scope)
- Can update retention and cleanup policies

**Update partitions number**

```
$ terraform apply
kafka_topic.my-test: Refreshing state... (ID: test12)
kafka_topic.my-test: Modifying...
  partitions: "5" => "6"
kafka_topic.my-test: Modifications complete

#verify
$ kafka-topics.sh --zookeeper localhost --describe --topic test12
Topic:test12    PartitionCount:6    ReplicationFactor:1 Configs:retention.ms=86000,cleanup.policy=compact
    Topic: test12   Partition: 0    Leader: 0   Replicas: 0 Isr: 0
    Topic: test12   Partition: 1    Leader: 0   Replicas: 0 Isr: 0
    Topic: test12   Partition: 2    Leader: 0   Replicas: 0 Isr: 0
    Topic: test12   Partition: 3    Leader: 0   Replicas: 0 Isr: 0
    Topic: test12   Partition: 4    Leader: 0   Replicas: 0 Isr: 0
    Topic: test12   Partition: 5    Leader: 0   Replicas: 0 Isr: 0
```

**Update policies**

```
$ terraform apply
kafka_topic.my-test: Refreshing state... (ID: my-test)
kafka_topic.my-test: Modifying...
  cleanup_policy: "" => "compact"
  retention_ms:   "600000" => "300000"
kafka_topic.my-test: Modifications complete

#verification
$ kafka-topics.sh --zookeeper localhost --describe --topic my-test
Topic:my-test   PartitionCount:2    ReplicationFactor:1 Configs:retention.ms=300000,cleanup.policy=compact
    Topic: my-test  Partition: 0    Leader: 0   Replicas: 0 Isr: 0
    Topic: my-test  Partition: 1    Leader: 0   Replicas: 0 Isr: 0
```

ping @newhoggy 
