### PR TITLE
MAYH-2162 Finding kafka scripts.

### DIFF
--- a/kafka_client.go
+++ b/kafka_client.go
@@ -9,7 +9,7 @@ import (
   "fmt"
 )
 
-// Client does client stuff.
+// KafkaManagingClient does client stuff.
 type KafkaManagingClient struct {
   Zookeeper   string
   TopicScript string
@@ -64,7 +64,7 @@ func (client *KafkaManagingClient) createTopic(name string, conf *KafkaTopicInfo
   confOpts := conf.createTopicConfigOpts()
   params = append(params, confOpts...)
 
-  log.Println("[DEBUG] Will execute %v", params)
+  log.Printf("[DEBUG] Will execute %v", params)
 
   cmd := exec.Command(client.TopicScript, params...)
 
@@ -170,4 +170,3 @@ func getOrDefaultInt(m map[string]string, key string, def int64) int64 {
   }
   return def
 }
-

--- a/sample/sample.tf
+++ b/sample/sample.tf
@@ -1,6 +1,5 @@
 provider "kafka" {
   zookeeper = "localhost"
-  kafka_bin_path = "/Users/alexey/Work/kafka/bin"
 }
 
 resource "kafka_topic" "my-test" {


### PR DESCRIPTION
The Kafka Terraform plugin now searches Kafka executables according to the following rules:

If `kafka_bin_path` is set, then choose the first valid executable out of:
- `[kafka_bin_path/kafka-topics, kafka_bin_path/kafka-topics.sh]`
- `[kafka_bin_path/kafka-configs, kafka_bin_path/kafka-configs.sh]`

If `kafka_bin_path` is not set, then choose the first valid executable out of:
- `[which kafka-topics, which kafka-topics.sh]`
- `[which kafka-configs, which kafka-configs.sh]`

The executable path resolution depends on the unix `which` shell command.
