### PR TITLE
use new .sh output to confirm success

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,17 +7,17 @@ machine:
   post:
     - mkdir -p download
     - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
-    - sudo rm -rf /usr/local/go
-    - sudo tar -C /usr/local -xzf download/$GODIST
+    - rm -rf /usr/local/go
+    - tar -C /usr/local -xzf download/$GODIST
 
 dependencies:
   cache_directories:
     - ~/download
   pre:
-    - sudo mkdir -p ~/.go_workspace/src
-    - sudo add-apt-repository ppa:masterminds/glide -y
-    - sudo apt-get update
-    - sudo apt-get install glide -y
+    - mkdir -p ~/.go_workspace/src
+    - add-apt-repository ppa:masterminds/glide -y
+    - apt-get update
+    - apt-get install glide -y
   override:
     - glide install
     - mkdir -p "$PROJECT_DIR"

--- a/circle.yml
+++ b/circle.yml
@@ -7,21 +7,21 @@ machine:
   post:
     - mkdir -p download
     - test -e download/$GODIST || curl -o download/$GODIST https://storage.googleapis.com/golang/$GODIST
-    - rm -rf /usr/local/go
-    - tar -C /usr/local -xzf download/$GODIST
+    - sudo rm -rf /usr/local/go
+    - sudo tar -C /usr/local -xzf download/$GODIST
 
 dependencies:
   cache_directories:
     - ~/download
   pre:
-    - mkdir -p ~/.go_workspace/src
-    - add-apt-repository ppa:masterminds/glide -y
-    - apt-get update
-    - apt-get install glide -y
+    - sudo mkdir -p ~/.go_workspace/src
+    - sudo add-apt-repository ppa:masterminds/glide -y
+    - sudo apt-get update
+    - sudo apt-get install glide -y
   override:
     - glide install
-    - mkdir -p "$PROJECT_DIR"
-    - rsync -az --delete ./ "$PROJECT_DIR"
+    - sudo mkdir -p "$PROJECT_DIR"
+    - sudo rsync -az --delete ./ "$PROJECT_DIR"
 
 test:
   override:

--- a/kafka_client.go
+++ b/kafka_client.go
@@ -41,7 +41,7 @@ func (client *KafkaManagingClient) alterTopicConfig(name string, conf *KafkaTopi
 	log.Printf("Will update configs for topic %s: %v", name, confOpts)
 	cmd := exec.Command(client.ConfigScript, params...)
 
-	return execKafkaCommand(cmd, "Updated config for topic:")
+	return execKafkaCommand(cmd, "Completed Updating config for entity: topic")
 }
 
 func (client *KafkaManagingClient) deleteTopic(name string) error {


### PR DESCRIPTION
The output of the ConfigCommand changed between kafka 0.10.1 and 0.10.2

https://github.com/apache/kafka/blob/0.10.2/core/src/main/scala/kafka/admin/ConfigCommand.scala#L108

https://github.com/apache/kafka/blob/0.10.1/core/src/main/scala/kafka/admin/ConfigCommand.scala#L96