### PR TITLE
Feature/mayh 7195 tagging release fails

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,6 @@ dependencies:
     - sudo add-apt-repository ppa:masterminds/glide -y
     - sudo apt-get update
     - sudo apt-get install glide -y
-    - go get github.com/tcnksm/ghr
   override:
     - glide install
     - sudo mkdir -p "$PROJECT_DIR"

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,6 @@ deployment:
   release:
     tag: /v.*/
     commands:
-      - go get github.com/mitchellh/gox
       - |
         cd "$PROJECT_DIR" && \
         gox -osarch="netbsd/arm" \

--- a/circle.yml
+++ b/circle.yml
@@ -18,6 +18,7 @@ dependencies:
     - sudo add-apt-repository ppa:masterminds/glide -y
     - sudo apt-get update
     - sudo apt-get install glide -y
+    - go get github.com/tcnksm/ghr
   override:
     - glide install
     - sudo mkdir -p "$PROJECT_DIR"
@@ -32,7 +33,6 @@ deployment:
     tag: /v.*/
     commands:
       - go get github.com/mitchellh/gox
-      - go get github.com/tcnksm/ghr
       - |
         cd "$PROJECT_DIR" && \
         gox -osarch="netbsd/arm" \

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 8662dd9e02e27be2fd790577444e920faee936a17b487c38b88ef735483b3ad4
-updated: 2016-10-05T15:57:26.87129871+10:00
+hash: cf755f90d56cdc56612b86eb60e01f46d5df2e2d2c78a5c3cab36c1b39d9cd3d
+updated: 2017-12-06T16:13:26.26698637+10:00
 imports:
 - name: github.com/apparentlymart/go-cidr
   version: a3ebdb999b831ecb6ab8a226e31b07b2b9061c47
@@ -118,8 +118,12 @@ imports:
   version: 80adcec1955ee4e97af357c30dee61aadcc02c10
 - name: github.com/mitchellh/go-homedir
   version: d682a8f0cf139663a984ff12528da460ca963de9
+- name: github.com/mitchellh/gox
+  version: c9740af9c6574448fd48eb30a71f964014c7a837
 - name: github.com/mitchellh/mapstructure
   version: 281073eb9eb092240d33ef253c404f1cca550309
 - name: github.com/mitchellh/reflectwalk
   version: eecf4c70c626c7cfbb95c90195bc34d386c74ac6
+- name: github.com/tcnksm/ghr
+  version: 74b0ef1bea6bdc603c2a4bc77ce83b30775e3699
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,3 +6,8 @@ import:
   - helper/schema
   - plugin
   - terraform
+- package: github.com/tcnksm/ghr
+  version: 0.4.0
+- package: github.com/mitchellh/gox
+  version: 0.4.0
+


### PR DESCRIPTION
Control the versions of github.com/mitchellh/gox and github.com/tcnksm/ghr with glide package manager.