### PR TITLE
Feature/mayh 7195 use go1.8

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,8 @@ deployment:
   release:
     tag: /v.*/
     commands:
+      - go get github.com/tcnksm/ghr
+      - go get github.com/mitchellh/gox 
       - |
         cd "$PROJECT_DIR" && \
         gox -osarch="netbsd/arm" \

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    GODIST: "go1.6.linux-amd64.tar.gz"
+    GODIST: "go1.8.linux-amd64.tar.gz"
     IMPORT_PATH: "github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
     PROJECT_DIR: "/home/ubuntu/.go_workspace/src/$IMPORT_PATH"
 

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,8 +6,4 @@ import:
   - helper/schema
   - plugin
   - terraform
-- package: github.com/tcnksm/ghr
-  version: 0.4.0
-- package: github.com/mitchellh/gox
-  version: 0.4.0
 


### PR DESCRIPTION
Use go 1.8 to build the plugin and move back to installing ghr and gox via go get rather than glide.
